### PR TITLE
Adds a "fast" and "full" mode for resource scan

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 chucksellick, David McWilliams
+Copyright (c) 2022 Patrick Souza
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Deconstruction and upgrades use X,Y as the center of the area. This can be chang
 The mod also adds a Resource Scanner that can help detect places to build.
 
 ![Resource Scanner](docs/scanner.png)
+
+## Patorio additions
+
+On-tick and on deconstruction planner applied by player, resource scanners check for friendly entities queued for deconstruction, output on `siganl-D` in the circuit network.

--- a/control.lua
+++ b/control.lua
@@ -9,6 +9,7 @@ function on_init()
   global.networks = {}
   global.scanners = {}
   global.blueprints = {}
+  global.scanner_update_index = nil
   on_mods_changed()
 end
 
@@ -86,7 +87,7 @@ function on_setting_changed(event)
   end
 end
 
-function on_tick()
+function on_tick(event)
   -- Check one deployer per tick for new circuit network connections
   local index = global.deployer_index
   global.deployer_index = next(global.deployers, global.deployer_index)
@@ -99,7 +100,7 @@ function on_tick()
     end
   end
 
-  -- Read all circuit networks
+  -- Read all circuit networks 
   for _, network in pairs(global.networks) do
     if network.deployer.valid then
       if network.red and not network.red.valid then
@@ -113,6 +114,15 @@ function on_tick()
       else
         on_tick_deployer(network)
       end
+    end
+  end
+
+  -- Update all scanners with "cheap pass", one scanner per tick
+  local index = global.scanner_update_index
+  global.scanner_update_index = next(global.scanners, global.scanner_update_index)
+  if global.scanners[index] then
+    if global.scanners[index].entity.valid then
+      scan_resources(global.scanners[index], false)
     end
   end
 end

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
-  "name":"recursive-blueprints",
-  "author":"Doc, justarandomgeek, DaveMcW",
-  "version":"1.2.6",
-  "title":"Recursive Blueprints",
+  "name":"patorio-recursive-blueprints",
+  "author":"Patrick Souza",
+  "version":"0.1.0",
+  "title":"Patorio Recursive Blueprints",
   "homepage":"",
-  "description":"Automate blueprints to build a self-expanding factory.",
+  "description":"Fork of Recursive Blueprints with deconstruction tracking.",
   "dependencies": ["base"],
   "factorio_version": "1.1"
 }

--- a/makerelease.sh
+++ b/makerelease.sh
@@ -7,7 +7,7 @@ modname=`cat info.json|jq -r .name`
 modver=`cat info.json|jq -r .version`
 
 # Create git tag for this version 
-git tag "$modver"
+# git tag "$modver"
 
 # Prepare zip for Factorio native use and mod portal
 git archive --prefix "${modname}_$modver/" -o "${modname}_$modver.zip" HEAD

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -1,20 +1,20 @@
 -- Blueprint deployer
 local deployer = table.deepcopy(data.raw["container"]["steel-chest"])
 deployer.name = "blueprint-deployer"
-deployer.icon = "__recursive-blueprints__/graphics/blueprint-deployer-icon.png"
+deployer.icon = "__patorio-recursive-blueprints__/graphics/blueprint-deployer-icon.png"
 deployer.minable.result = "blueprint-deployer"
 deployer.inventory_size = 1
 deployer.enable_inventory_bar = false
 deployer.se_allow_in_space = true
 deployer.picture.layers = {
   {
-    filename = "__recursive-blueprints__/graphics/blueprint-deployer.png",
+    filename = "__patorio-recursive-blueprints__/graphics/blueprint-deployer.png",
     width = 32,
     height = 36,
     shift = util.by_pixel(0, -2),
     priority = "high",
     hr_version = {
-      filename = "__recursive-blueprints__/graphics/hr-blueprint-deployer.png",
+      filename = "__patorio-recursive-blueprints__/graphics/hr-blueprint-deployer.png",
       width = 66,
       height = 72,
       shift = util.by_pixel(0, -2.5),
@@ -70,7 +70,7 @@ data:extend{
       "hide-alt-info",
       "not-rotatable",
     },
-    icon = "__recursive-blueprints__/graphics/scanner-icon.png",
+    icon = "__patorio-recursive-blueprints__/graphics/scanner-icon.png",
     icon_mipmaps = 4,
     icon_size = 64,
     item_slot_count = 10,
@@ -81,13 +81,13 @@ data:extend{
     sprites = {
       layers = {
         {
-          filename = "__recursive-blueprints__/graphics/scanner.png",
+          filename = "__patorio-recursive-blueprints__/graphics/scanner.png",
           width = 69,
           height = 135,
           shift = util.by_pixel(0, -31),
           priority = "high",
           hr_version = {
-            filename = "__recursive-blueprints__/graphics/hr-scanner.png",
+            filename = "__patorio-recursive-blueprints__/graphics/hr-scanner.png",
             width = 138,
             height = 270,
             shift = util.by_pixel(0, -31),

--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -2,7 +2,7 @@ data:extend{
   {
     type = "item",
     name = "blueprint-deployer",
-    icon = "__recursive-blueprints__/graphics/blueprint-deployer-icon.png",
+    icon = "__patorio-recursive-blueprints__/graphics/blueprint-deployer-icon.png",
     icon_size = 64,
     icon_mipmaps = 4,
     subgroup = "logistic-network",
@@ -13,7 +13,7 @@ data:extend{
   {
     type = "item",
     name = "recursive-blueprints-scanner",
-    icon = "__recursive-blueprints__/graphics/scanner-icon.png",
+    icon = "__patorio-recursive-blueprints__/graphics/scanner-icon.png",
     icon_size = 64,
     icon_mipmaps = 4,
     subgroup = "circuit-network",


### PR DESCRIPTION
Fast mode only checks for deconstructing entities. Full mode scans all
resources. Fast mode runs on-tick. Full mode on events that require a
full resource scan.

Update assent references

Cache resources on scanner table

merge on-tick events

Update license